### PR TITLE
Added the 'CPU' paramter. If only vcpu is defined, for example 4, tha…

### DIFF
--- a/virtTools.cpp
+++ b/virtTools.cpp
@@ -7,7 +7,7 @@
  * Authors:
  *  Christian Wittkowski <wittkowski@devroom.de>
  *
- * Licensed under the EUPL, Version 1.1 or – as soon they
+ * Licensed under the EUPL, Version 1.1 or â€“ as soon they
  * will be approved by the European Commission - subsequent
  * versions of the EUPL (the "Licence");
  * You may not use this work except in compliance with the
@@ -171,6 +171,9 @@ const string VirtTools::getVmXml(const Vm* vm) const {
 	buffer << "\t<uuid>" << vm->getName() << "</uuid>" << endl;
 	buffer << "\t<memory>" << vm->getMemoryKb() << "</memory>" << endl;
 	buffer << "\t<vcpu>" << vm->getVCpu() << "</vcpu>" << endl;
+	buffer << "\t<cpu>" << endl;
+	buffer << "\t\t<topology sockets=\"1\" cores=\"" << vm->getVCpu() << "\" threads=\"1\" />" << endl;
+	buffer << "\t</cpu>"
 	buffer << "\t<os>" << endl;
 	buffer << "\t\t<type arch=\"" << vm->getOsArchitecture() << "\" machine=\"" << vm->getOsMachine() << "\">"
 			<< vm->getOsType() << "</type>" << endl;


### PR DESCRIPTION
…n a mainboard with 4 sockets each containing a processor with one core is created. This prevents non Windows Server from using all cores. So if you give a machine 4 vcpu, then the OS can only use 2 of them, which isn't what the user expects selecting 4 VCPU. So it might be better to select one socket with the user selected amount of CPU cores. All of our VMs makes the CPU changing just fine (also Windows Server 2012 R2)